### PR TITLE
Dont overwrite window.language

### DIFF
--- a/item-info.coffee
+++ b/item-info.coffee
@@ -11,7 +11,6 @@ i18n.configure
   indent: '\t'
   extension: '.json'
 
-window.language = config.get 'poi.language', navigator.language
 i18n.setLocale(window.language)
 window.__ = i18n.__
 


### PR DESCRIPTION
`window.language` is configured in `env.coffee`.
