### PR TITLE
Added tooltip to display item stats at mouse hovering on the item icon

### DIFF
--- a/views/item-info-table-area.es
+++ b/views/item-info-table-area.es
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Grid, Table, FormControl, OverlayTrigger } from 'react-bootstrap'
+import { Grid, Table, FormControl, OverlayTrigger, Tooltip } from 'react-bootstrap'
 import { connect } from 'react-redux'
 import { get, map, flatten, sortBy } from 'lodash'
 import path from 'path'
@@ -55,11 +55,25 @@ const ItemInfoTable = ({ row }) => {
   const itemData = $equip && getItemData($equip).map((data, propId) =>
     <div key={propId}>{data}</div>
   )
+  const itemOverlay = itemData &&
+    <Tooltip id={`$equip-${$equip.api_id}`}>
+      <div> { itemData } </div>
+    </Tooltip>
+  const slotItemIconSpan = 
+    <span>
+      <SlotitemIcon slotitemId={row.api_type[3]} />
+    </span>
+
   return (
     <tr className="vertical">
       <td className="item-name-cell">
         {
-          <SlotitemIcon slotitemId={row.api_type[3]} />
+          itemOverlay ?
+            <OverlayTrigger placement='left' overlay={itemOverlay}>
+              {slotItemIconSpan}
+            </OverlayTrigger>
+            :
+            slotItemIconSpan
         }
         {i18n.resources.__(row.api_name)}
       </td>

--- a/views/item-info-table-area.es
+++ b/views/item-info-table-area.es
@@ -52,10 +52,10 @@ ShipTag.WrappedComponent.propTypes = {
 const ItemInfoTable = ({ row }) => {
   const { total, active, lvCount, lvShip, hasAlv, hasLevel } = row
 
-  const itemData = row && getItemData(row).map((data, propId) =>
+  const itemData = getItemData(row).map((data, propId) =>
     <div key={propId}>{data}</div>
   )
-  const itemOverlay = itemData &&
+  const itemOverlay = itemData.length &&
     <Tooltip id={`$equip-${row.api_id}`}>
       <div> { itemData } </div>
     </Tooltip>

--- a/views/item-info-table-area.es
+++ b/views/item-info-table-area.es
@@ -1,11 +1,12 @@
 import React, { Component } from 'react'
-import { Grid, Table, FormControl } from 'react-bootstrap'
+import { Grid, Table, FormControl, OverlayTrigger } from 'react-bootstrap'
 import { connect } from 'react-redux'
 import { get, map, flatten, sortBy } from 'lodash'
 import path from 'path'
 import PropTypes from 'prop-types'
 
 import { SlotitemIcon } from 'views/components/etc/icon'
+import { getItemData } from 'views/components/ship/slotitems-data'
 
 import { rowsSelector, iconEquipMapSelector, reduceShipDataSelectorFactory, reduceAirbaseSelectorFactory } from './selectors'
 import { int2BoolArray, getLevelsFromKey } from './utils'

--- a/views/item-info-table-area.es
+++ b/views/item-info-table-area.es
@@ -50,13 +50,13 @@ ShipTag.WrappedComponent.propTypes = {
 }
 
 const ItemInfoTable = ({ row }) => {
-  const { $equip, total, active, lvCount, lvShip, hasAlv, hasLevel } = row
+  const { total, active, lvCount, lvShip, hasAlv, hasLevel } = row
 
-  const itemData = $equip && getItemData($equip).map((data, propId) =>
+  const itemData = row && getItemData(row).map((data, propId) =>
     <div key={propId}>{data}</div>
   )
   const itemOverlay = itemData &&
-    <Tooltip id={`$equip-${$equip.api_id}`}>
+    <Tooltip id={`$equip-${row.api_id}`}>
       <div> { itemData } </div>
     </Tooltip>
   const slotItemIconSpan = 

--- a/views/item-info-table-area.es
+++ b/views/item-info-table-area.es
@@ -50,8 +50,11 @@ ShipTag.WrappedComponent.propTypes = {
 }
 
 const ItemInfoTable = ({ row }) => {
-  const { total, active, lvCount, lvShip, hasAlv, hasLevel } = row
+  const { $equip, total, active, lvCount, lvShip, hasAlv, hasLevel } = row
 
+  const itemData = $equip && getItemData($equip).map((data, propId) =>
+    <div key={propId}>{data}</div>
+  )
   return (
     <tr className="vertical">
       <td className="item-name-cell">


### PR DESCRIPTION
Motivation: Every now and then I would like to read or compare equipment stats while using the item-info plugin, but previously the equipment stats were not displayed. Therefore I've incorporated this feature into the plugin.

Method: The code is mostly stolen from POI implementation since I'm quite new to Node/React/Redux.

Debugging: ^Works ^On ^^My ^^Machine
